### PR TITLE
rewrite as middleware instead of store enhancer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export type Handler<Action, Effect> = (Dispatch<Action>) => (Effect) => void;
 /*
  * The result of `initEffects`.
  */
-type Couple<A, E> = { emit: Emit<E>, enhancer: * }; // FIXME the enhancer type
+type Couple<A, E> = { emit: Emit<E>, middleware: * }; // FIXME the enhancer type
 
 /*
  * Given an effect handler, returns the `emit` function and the store enhancer.
@@ -57,26 +57,7 @@ export function initEffects<A, E>(handler: Handler<A, E>): Couple<A, E> {
     sink.push(effect);
   }
 
-  const enhancer = (createStore: *) => (...args: *[]) => {
-    /*
-     * We are about to create the store. Since the reducer might get called, 
-     * reset the sink to `blackhole` to prevent any unwanted effects getting
-     * pushed into `initialEffects`.
-     */
-    sink = blackhole;
-
-    /*
-     * The not-yet-enhanced Redux store.
-     */
-    const store = createStore(...args);
-
-    /*
-     * It is important to pass `dispatch`, not `store.dispatch` here. Otherwise,
-     * if the handler dispatches an action, none of the subsequent effects
-     * emitted during that dispatch will get performed.
-     */
-    const perform = handler(dispatch);
-
+  const middleware = store => next => action => {
     /*
      * Self-explanatory.
      */
@@ -88,7 +69,7 @@ export function initEffects<A, E>(handler: Handler<A, E>): Couple<A, E> {
          * performed.
          */
         try {
-          perform(effects[i]);
+          handler(store.dispatch)(effects[i]);
         } catch(e) {
           console.error('While performing an effect:', e);
         }
@@ -96,60 +77,39 @@ export function initEffects<A, E>(handler: Handler<A, E>): Couple<A, E> {
     }
 
     /*
-     * The dispatcher which will actually perform any emitted effects.
+     * Create a new temporary array to emit effects into. All effects emitted
+     * during the reducer execution will get pushed into this array.
      */
-    function dispatch(action) {
-      /*
-       * Create a new temporary array to emit effects into. All effects emitted
-       * during the reducer execution will get pushed into this array.
-       */
-      sink = [];
-
-      /*
-       * The reducer will get executed here by Redux.
-       */
-      store.dispatch(action);
-
-      /*
-       * Since we are going to reset the "sink", we need to save the
-       * resulting array of emitted effects for the closure.
-       */
-      const queuedEffects = sink;
-
-      /*
-       * Perform all queued effects asyncronously. Async is important here,
-       * because performing an effect may `dispatch`, which would be a recursive
-       * call.
-       */
-      setTimeout(() => performAll(queuedEffects), 0);
-
-      /*
-       * We are done. To prevent any inner dispatches (e.g. Redux Dev Tools) or
-       * extraneous `emit` calls from performing any effects, we reset the sink
-       * to `blackhole`, i.e. ignore everything.
-       */
-      sink = blackhole;
-    }
+    sink = [];
 
     /*
-     * A small convenience: all "initial" effects (emitted before the store
-     * creation) will end up inside the `initialEffects` array. We perform them
-     * immediately after the store is created.
-     *
-     * We can do this syncronously, since `performAll` can't throw. This gives
-     * us an absolute guarantee that the initial effects actually get performed
-     * before anything else.
+     * The reducer will get executed here by Redux.
      */
-    performAll(initialEffects);
+    next(action);
 
-    return {
-      ...store,
-      dispatch,
-    };
+    /*
+     * Since we are going to reset the "sink", we need to save the
+     * resulting array of emitted effects for the closure.
+     */
+    const queuedEffects = sink;
+
+    /*
+     * Perform all queued effects asyncronously. Async is important here,
+     * because performing an effect may `dispatch`, which would be a recursive
+     * call.
+     */
+    setTimeout(() => performAll(queuedEffects), 0);
+
+    /*
+     * We are done. To prevent any inner dispatches (e.g. Redux Dev Tools) or
+     * extraneous `emit` calls from performing any effects, we reset the sink
+     * to `blackhole`, i.e. ignore everything.
+     */
+    sink = blackhole;
   }
 
   /*
    * That's it, folks!
    */
-  return { enhancer, emit };
+  return { middleware, emit };
 }


### PR DESCRIPTION
Don't assume I'm obsessed with doing things via middleware :smile:  I just realized that it's not necessary to implement Petux as a store enhancer, and I wanted to demonstrate how it would work as middleware, since it would be less invasive than a store enhancer.